### PR TITLE
Enhanced "Commands selection" experience

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,7 @@
 (function() {
-	var ignoreList = localStorage.getItem("ignoreList") ? JSON.parse(localStorage.getItem("ignoreList")) : []
-	var command = function(name, callback){
+	var ignoreList = localStorage.getItem("ignoreList") ? JSON.parse(localStorage.getItem("ignoreList")) : [];
+
+	var Command = function(name, callback){
 		this.name = name;
 		this.callback = callback;
 		this.execute = function(parameters) {
@@ -15,19 +16,19 @@
 	}
 
 	var commands = {
-		collapse: new command('collapse', collapseAll),
-		uncollapse: new command('uncollapse', unCollapseAll),
-		shruggie: new command('shruggie', shruggie),
-		norris: new command('norris', getNorris),
-		skeet: new command('skeet', getSkeet),
-		cat: new command('cat', getCat),
-		replyLast: new command('replyLast', replyLast),
-		giphy: new command('giphy', giphyStuff),
-		glink: new command('glink', giphyShorten),
-		ignore: new command('ignore', ignoreUsers),
-		coin: new command('coin', flipACoin),
-		dice: new command('dice', rollADice),
-		unignore: new command('unignore', unignoreUsers)
+		collapse: new Command('collapse', collapseAll),
+		uncollapse: new Command('uncollapse', unCollapseAll),
+		shruggie: new Command('shruggie', shruggie),
+		norris: new Command('norris', getNorris),
+		skeet: new Command('skeet', getSkeet),
+		cat: new Command('cat', getCat),
+		replyLast: new Command('replyLast', replyLast),
+		giphy: new Command('giphy', giphyStuff),
+		glink: new Command('glink', giphyShorten),
+		ignore: new Command('ignore', ignoreUsers),
+		coin: new Command('coin', flipACoin),
+		dice: new Command('dice', rollADice),
+		unignore: new Command('unignore', unignoreUsers)
 	};
 
 	function clearInput() {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "content_scripts": [
     {
 		  "matches" : ["*://chat.stackoverflow.com/*","*://chat.stackexchange.com/*","*://chat.meta.stackexchange.com/*"],
-      "js":["background.js"]
+      "js":["background.js"],
+      "css" : ["style.css"]
     }
   ],
   "browser_action": {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,6 @@
+.curr-command {
+  border: 2px solid #3aa3ff;
+  border-radius: 4px;
+  background-color: #faebd7;
+  padding: 3px;
+}


### PR DESCRIPTION
You can now use **tab** or **shift+tab** to move through the selection of commands, when they are displayed. The directions goes around (if you _tab_ at the last element, it goes back to the first, same backwards). I've also changed the commands displayed to be the ones containing the substring given, without having to start with the substring.

E.g. **/s** returns `collapse norris replyLast shruggie skeet uncollapse` rather than `shruggie skeet`. Notice also that the list returned is always in alphabetical order!

When you are on the command you want to use, simply press `Enter`, and it will fill it in **WITHOUT** sending the message.

![Demo](http://g.recordit.co/v7lOvmxY35.gif)

As an aside, I've changed styling of `command` to `Command`.
